### PR TITLE
Postgres 15 Tooling

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM apache/airflow:2.5.0-python3.10
+FROM apache/airflow:2.2.2-python3.8
 
 MAINTAINER jbarry <john.barry@leaftrade.com>
 
@@ -7,7 +7,7 @@ COPY requirements.txt /requirements.txt
 RUN  pip install pytz \
     && pip install ndg-httpsclient \
     && pip install pyasn1 \
-    && pip install 'apache-airflow[amazon,google,celery,password,postgres,redis,slack]==2.5.0'\
+    && pip install 'apache-airflow[amazon,google,celery,password,postgres,redis,slack]==2.2.2'\
     && pip install --requirement /requirements.txt 
 
 COPY config/airflow.cfg ${AIRFLOW_HOME}/airflow.cfg

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -7,7 +7,7 @@ COPY requirements.txt /requirements.txt
 RUN  pip install pytz \
     && pip install ndg-httpsclient \
     && pip install pyasn1 \
-    && pip install 'apache-airflow[amazon,google,celery,password,postgres,redis,slack]==2.2.2'\
+    && pip install 'apache-airflow[amazon,google,celery,password,postgres,redis,slack]==2.5.0'\
     && pip install --requirement /requirements.txt 
 
 COPY config/airflow.cfg ${AIRFLOW_HOME}/airflow.cfg

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -2,6 +2,15 @@ FROM apache/airflow:2.2.2-python3.8
 
 MAINTAINER jbarry <john.barry@leaftrade.com>
 
+#Hardcoded version until we find a better solution, this sucks
+RUN apt remove -y postgresql-client-11 &&\
+    apt update &&\
+    apt install -y wget &&\
+    sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list' &&\
+    wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add - &&\
+    apt update &&\
+    apt install -y postgresql-client-15
+
 COPY requirements.txt /requirements.txt
 
 RUN  pip install pytz \
@@ -14,15 +23,6 @@ COPY config/airflow.cfg ${AIRFLOW_HOME}/airflow.cfg
 
 RUN curl https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem > ${AIRFLOW_HOME}/awssslcert.pem
 #RUN chown -R airflow: ${AIRFLOW_HOME}
-
-#Hardcoded version until we find a better solution, this sucks
-RUN apt remove -y postgresql-client-11 &&\
-    apt update &&\
-    apt install -y wget &&\
-    sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list' &&\
-    wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add - &&\
-    apt update &&\
-    apt install -y postgresql-client-15
 
 EXPOSE 8080 5555 8793 6739
 

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM apache/airflow:2.2.2-python3.8
+FROM apache/airflow:2.5.0-python3.10
 
 MAINTAINER jbarry <john.barry@leaftrade.com>
 
@@ -7,7 +7,7 @@ COPY requirements.txt /requirements.txt
 RUN  pip install pytz \
     && pip install ndg-httpsclient \
     && pip install pyasn1 \
-    && pip install 'apache-airflow[amazon,google,celery,password,postgres,redis,slack]==2.2.2'\
+    && pip install 'apache-airflow[amazon,google,celery,password,postgres,redis,slack]==2.5.0'\
     && pip install --requirement /requirements.txt 
 
 COPY config/airflow.cfg ${AIRFLOW_HOME}/airflow.cfg

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -2,15 +2,6 @@ FROM apache/airflow:2.2.2-python3.8
 
 MAINTAINER jbarry <john.barry@leaftrade.com>
 
-#Hardcoded version until we find a better solution, this sucks
-RUN sudo apt remove -y postgresql-client-11 &&\
-    sudo apt update &&\
-    sudo apt install -y wget &&\
-    sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list' &&\
-    wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add - &&\
-    sudo apt update &&\
-    sudo apt install -y postgresql-client-15
-
 COPY requirements.txt /requirements.txt
 
 RUN  pip install pytz \
@@ -23,6 +14,16 @@ COPY config/airflow.cfg ${AIRFLOW_HOME}/airflow.cfg
 
 RUN curl https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem > ${AIRFLOW_HOME}/awssslcert.pem
 #RUN chown -R airflow: ${AIRFLOW_HOME}
+
+USER root
+#Hardcoded version until we find a better solution, this sucks
+RUN apt remove -y postgresql-client-11 &&\
+    apt update &&\
+    apt install -y wget &&\
+    sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list' &&\
+    wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add - &&\
+    apt update &&\
+    apt install -y postgresql-client-15
 
 EXPOSE 8080 5555 8793 6739
 

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -10,6 +10,8 @@ RUN  pip install pytz \
     && pip install 'apache-airflow[amazon,google,celery,password,postgres,redis,slack]==2.5.0'\
     && pip install --requirement /requirements.txt 
 
+RUN airflow db upgrade
+
 COPY config/airflow.cfg ${AIRFLOW_HOME}/airflow.cfg
 
 RUN curl https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem > ${AIRFLOW_HOME}/awssslcert.pem

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -3,13 +3,13 @@ FROM apache/airflow:2.2.2-python3.8
 MAINTAINER jbarry <john.barry@leaftrade.com>
 
 #Hardcoded version until we find a better solution, this sucks
-RUN apt remove -y postgresql-client-11 &&\
-    apt update &&\
-    apt install -y wget &&\
+RUN sudo apt remove -y postgresql-client-11 &&\
+    sudo apt update &&\
+    sudo apt install -y wget &&\
     sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list' &&\
     wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add - &&\
-    apt update &&\
-    apt install -y postgresql-client-15
+    sudo apt update &&\
+    sudo apt install -y postgresql-client-15
 
 COPY requirements.txt /requirements.txt
 

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -10,8 +10,6 @@ RUN  pip install pytz \
     && pip install 'apache-airflow[amazon,google,celery,password,postgres,redis,slack]==2.5.0'\
     && pip install --requirement /requirements.txt 
 
-RUN airflow db upgrade
-
 COPY config/airflow.cfg ${AIRFLOW_HOME}/airflow.cfg
 
 RUN curl https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem > ${AIRFLOW_HOME}/awssslcert.pem

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -15,6 +15,15 @@ COPY config/airflow.cfg ${AIRFLOW_HOME}/airflow.cfg
 RUN curl https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem > ${AIRFLOW_HOME}/awssslcert.pem
 #RUN chown -R airflow: ${AIRFLOW_HOME}
 
+#Hardcoded version until we find a better solution, this sucks
+RUN apt remove -y postgresql-client-11 &&\
+    apt update &&\
+    apt install -y wget &&\
+    sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list' &&\
+    wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add - &&\
+    apt update &&\
+    apt install -y postgresql-client-15
+
 EXPOSE 8080 5555 8793 6739
 
 USER airflow

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -7,7 +7,7 @@ COPY requirements.txt /requirements.txt
 RUN  pip install pytz \
     && pip install ndg-httpsclient \
     && pip install pyasn1 \
-    && pip install 'apache-airflow[amazon,google,celery,password,postgres,redis,slack]==2.5.0'\
+    && pip install 'apache-airflow[amazon,google,celery,password,postgres,redis,slack]==2.2.2'\
     && pip install --requirement /requirements.txt 
 
 COPY config/airflow.cfg ${AIRFLOW_HOME}/airflow.cfg


### PR DESCRIPTION
## Description of the change

This isn't the most elegant way to do this, once we figure out how to upgrade airflow we should stop doing it this way. Hopefully newer versions of airflow come with newer versions of postgres tools

- Rip out old postgres from airflow:2.2.2
- Install postgres 15 tooling

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 

