### PR TITLE
RM PG11

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -17,8 +17,7 @@ RUN curl https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem > ${AIRFLOW
 
 USER root
 #Hardcoded version until we find a better solution, this sucks
-RUN apt remove -y postgresql-client-11 &&\
-    apt update &&\
+RUN apt update &&\
     apt install -y wget &&\
     sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list' &&\
     wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add - &&\


### PR DESCRIPTION
## Description of the change

- I think we used to remove pg11 to install pg15 on the old image, the new image we're building from doesn't seem to have pg11 installed so we're gonna remove that
- We should still maybe find a better way to install the latest postgres without hardcoding "15"?

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 

